### PR TITLE
Add option to pass a custom logger to Rebugger

### DIFF
--- a/rebugger/src/main/java/com/theapache64/rebugger/Rebugger.kt
+++ b/rebugger/src/main/java/com/theapache64/rebugger/Rebugger.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import java.sql.Ref
 
 private const val TAG = "Rebugger"
 
@@ -17,11 +16,12 @@ private class Ref<T>(var value: T)
 @Composable
 fun Rebugger(
     trackMap: Map<String, Any?>,
+    logger: (String) -> Unit = { message -> Log.i(TAG, message) },
     composableName: String = Thread.currentThread().stackTrace[3].methodName,
 ) {
 
     LaunchedEffect(Unit) {
-        Log.i(TAG, "🐞 Rebugger activated on `$composableName`")
+        logger("🐞 Rebugger activated on `$composableName`")
     }
 
     val count = remember { Ref(0) }
@@ -45,10 +45,10 @@ fun Rebugger(
     }
 
     if (changeLog.isNotEmpty()) {
-        Log.i(TAG, "🐞$composableName recomposed because $changeLog")
+        logger( "🐞$composableName recomposed because $changeLog")
     } else {
         if (count.value >= 1 && !flag.value) {
-            Log.i(TAG, "🐞$composableName recomposed not because of param change")
+            logger("🐞$composableName recomposed not because of param change")
         } else {
             flag.value = false
         }


### PR DESCRIPTION
This PR adds the option on `Rebugger` call to use a different logger method.

By default it keeps using the `Log` with `"Rebugger"` tag, but allows usage of this library to supply their own logger method

```kotlin
    Rebugger(
        trackMap = mapOf(
            "car" to car,
            "bike" to bike,
        ),
        logger = { message ->
            Timber.tag("AppTag").d(message)
        },
    )
```

Closes #5 